### PR TITLE
Add cli.sh to serve Laravel backend

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$1" = "serve" ]; then
+	cd backend/laravel || exit 1
+	php artisan serve
+else
+	echo "Usage: ./cli.sh serve"
+	exit 1
+fi


### PR DESCRIPTION
## What this PR does
Introduces a simple Bash CLI script that starts the Laravel development server. Running `./cli.sh serve` changes into `backend/laravel` and executes `php artisan serve`. Any other invocation prints usage and exits with code 1. The script includes a shebang and basic error handling when changing directories.

## Related Issue
Closes #6